### PR TITLE
fix: stabilize mobile Safari UI — prevent input zoom, keyboard occlusion, and overscroll

### DIFF
--- a/src/web/src/app.css
+++ b/src/web/src/app.css
@@ -35,6 +35,15 @@
 		background-color: hsl(var(--background));
 		color: hsl(var(--foreground));
 		font-family: "Inter", system-ui, -apple-system, sans-serif;
+		overscroll-behavior: none;
+		padding-left: env(safe-area-inset-left);
+		padding-right: env(safe-area-inset-right);
+	}
+
+	@media screen and (max-width: 767px) {
+		input, textarea, select {
+			font-size: 16px !important;
+		}
 	}
 
 	button, [role="button"] {

--- a/src/web/src/app.html
+++ b/src/web/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<link rel="icon" type="image/webp" href="/favicon.webp" />
 		%sveltekit.head%
 	</head>

--- a/src/web/src/routes/+layout.svelte
+++ b/src/web/src/routes/+layout.svelte
@@ -20,7 +20,7 @@ onMount(async () => {
 {#if ready}
 	{@render children()}
 {:else}
-	<div class="flex h-screen items-center justify-center">
+	<div class="flex h-screen h-dvh items-center justify-center">
 		<div class="text-muted-foreground">Loading...</div>
 	</div>
 {/if}

--- a/src/web/src/routes/+page.svelte
+++ b/src/web/src/routes/+page.svelte
@@ -247,9 +247,26 @@ onMount(() => {
 	document.addEventListener('keydown', handleKeydown);
 	document.addEventListener('visibilitychange', handleVisibilityChange);
 
+	// Track mobile virtual keyboard height to keep input visible
+	function updateKeyboardOffset() {
+		if (window.visualViewport) {
+			const offset = window.innerHeight - window.visualViewport.height;
+			document.documentElement.style.setProperty('--kb-offset', `${Math.max(0, offset)}px`);
+		}
+	}
+	if (window.visualViewport) {
+		window.visualViewport.addEventListener('resize', updateKeyboardOffset);
+		window.visualViewport.addEventListener('scroll', updateKeyboardOffset);
+	}
+
 	return () => {
 		document.removeEventListener('keydown', handleKeydown);
 		document.removeEventListener('visibilitychange', handleVisibilityChange);
+		if (window.visualViewport) {
+			window.visualViewport.removeEventListener('resize', updateKeyboardOffset);
+			window.visualViewport.removeEventListener('scroll', updateKeyboardOffset);
+		}
+		document.documentElement.style.removeProperty('--kb-offset');
 		websocket.off('new_message', handleNewMessage);
 		websocket.off('new_dm', handleNewDM);
 		websocket.off('edit_message', handleEditMessage);
@@ -325,7 +342,8 @@ function updateMessagePin(
 
 {#if auth.isLoggedIn}
 	<ConnectionBanner />
-	<div class="flex h-screen {layoutStore.anyDrawerOpen ? 'overflow-hidden' : ''}">
+	<div class="flex h-screen h-dvh {layoutStore.anyDrawerOpen ? 'overflow-hidden' : ''}"
+		 style="height: calc(100dvh - var(--kb-offset, 0px));">
 		<!-- Static sidebar (desktop) -->
 		<aside class="hidden md:flex w-60 shrink-0">
 			<ChannelSidebar />

--- a/src/web/src/routes/admin/+page.svelte
+++ b/src/web/src/routes/admin/+page.svelte
@@ -507,7 +507,7 @@ function switchTab(tab: typeof activeTab) {
 }
 </script>
 
-<div class="flex h-screen flex-col bg-background text-foreground">
+<div class="flex h-screen h-dvh flex-col bg-background text-foreground">
 	<!-- Header -->
 	<div class="flex items-center justify-between border-b border-border px-6 py-3">
 		<div class="flex items-center gap-3">


### PR DESCRIPTION
- Add viewport-fit=cover for safe-area-inset support on notched devices
- Force 16px font-size on mobile inputs to prevent Safari auto-zoom
- Add overscroll-behavior: none to prevent iOS rubber-band bounce
- Replace h-screen with h-dvh for dynamic viewport height (respects Safari address bar)
- Add visualViewport listener to shrink layout when virtual keyboard opens

https://claude.ai/code/session_01DzBJ7c1L1TBs6maf49WgLE